### PR TITLE
Changed the documentation version to 2.20

### DIFF
--- a/notebooks/Langchain-ElasticSearchVector-Ingest.ipynb
+++ b/notebooks/Langchain-ElasticSearchVector-Ingest.ipynb
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "import os as os\n",
-    "product_version = 2.18\n",
+    "product_version = 2.20\n",
     "CONNECTION_STRING = os.environ.get('CONNECTION_STRING', 'default')\n",
     "PASSWORD = os.environ.get('PASSWORD', 'default')\n",
     "COLLECTION_NAME = f\"rhoai-doc-{product_version}\""
@@ -314,7 +314,7 @@
     "    \"installing_and_uninstalling_openshift_ai_self-managed_in_a_disconnected_environment\",\n",
     "    \"upgrading_openshift_ai_self-managed\",\n",
     "    \"upgrading_openshift_ai_self-managed_in_a_disconnected_environment\",\n",
-    "    \"html/managing_openshift_ai\",\n",
+    "    \"managing_openshift_ai\",\n",
     "    \"configuring_the_model_registry_component\"\n",
     "]\n",
     "\n",


### PR DESCRIPTION
The 2.18 documentation version  no longer exists, so I changed to the 2.20 version instead.